### PR TITLE
Update task `explorer` to work with non-local networks

### DIFF
--- a/fixtures/blockscout/docker-compose.yml
+++ b/fixtures/blockscout/docker-compose.yml
@@ -28,8 +28,7 @@ services:
       -  ./envs/common-blockscout.env
     environment:
         ETHEREUM_JSONRPC_VARIANT: 'geth'
-        ETHEREUM_JSONRPC_HTTP_URL: http://host.docker.internal:8545/
-        ETHEREUM_JSONRPC_WS_URL: ws://host.docker.internal:8545/
+        ETHEREUM_JSONRPC_HTTP_URL: ${DOCKER_RPC_HTTP_URL:-http://host.docker.internal:8545/}
         INDEXER_DISABLE_PENDING_TRANSACTIONS_FETCHER: 'true'
         INDEXER_DISABLE_INTERNAL_TRANSACTIONS_FETCHER: ${DOCKER_DISABLE_TRACER:-true}
         DATABASE_URL: postgresql://postgres:@db:5432/blockscout?ssl=false

--- a/src/blockscout.ts
+++ b/src/blockscout.ts
@@ -1,6 +1,7 @@
 import axios, { AxiosError } from "axios";
 import child_process from "child_process";
 import { task } from "hardhat/config";
+import { HttpNetworkConfig } from "hardhat/types";
 import _ from "lodash";
 import path from "path";
 import process from "process";
@@ -15,13 +16,25 @@ task(TASK_EXPLORER, "Launch blockscout explorer")
   .addOptionalParam("port", "HTTP port", "4000")
   .addFlag("restart", "Restart container if there is one currently running")
   .addFlag("stop", "Stop containers and exit")
+  .addFlag("attachRemote", "Allow attach to remote RPC endpoint (may incur costs)")
   .addOptionalParam("explorerVersion", "Blockscout version (currently only supports 4.x.y)", "4.1.8")
   .setAction(async (taskArgs) => {
-    const { host, port, stop, restart, explorerVersion } = taskArgs;
+    const { host, port, stop, restart, attachRemote, explorerVersion } = taskArgs;
 
+    const dir = path.resolve(__dirname, "../fixtures/blockscout");
+    process.chdir(dir);
+
+    // stop container ASAP
+    if (stop) {
+      stopServer();
+      return;
+    }
+
+    const rpcUrl = await getRPCUrl(attachRemote);
     const url = `http://localhost:${port}`;
-    const disableTracer = await shouldDisableTracer()
+    const disableTracer = await shouldDisableTracer();
     const extraEnvs = {
+      'DOCKER_RPC_HTTP_URL': rpcUrl,
       'DOCKER_TAG': explorerVersion,
       'DOCKER_LISTEN': `${host}:${port}`,
       'DOCKER_DISABLE_TRACER': _.toString(disableTracer),
@@ -29,14 +42,8 @@ task(TASK_EXPLORER, "Launch blockscout explorer")
     _.assign(process.env, extraEnvs);
     console.log('[+] Using env:', extraEnvs);
 
-    const dir = path.resolve(__dirname, "../fixtures/blockscout");
-    process.chdir(dir);
-
     // Start containers
-    if (stop) {
-      stopServer();
-      return;
-    } else if (restart) {
+    if (restart) {
       stopServer();
     }
     startServer();
@@ -67,16 +74,45 @@ function stopServer() {
   child_process.execFileSync("docker-compose", ["down"], {stdio: 'inherit'});
 }
 
+async function getRPCUrl(attachRemote: boolean): Promise<string> {
+  const name = hre.network.name;
+  if (name == "hardhat") {
+    throw PluginError("Cannot run explorer for 'hardhat' network; Use --network localhost");
+  }
+  if (!attachRemote && name != "localhost") {
+    throw PluginError("Cannot run explorer for 'localhost' network; Use --attach-remote if you must");
+  }
+
+  if (name == "localhost") {
+    return "http://host.docker.internal:8545/";
+  }
+  const config = hre.network.config as HttpNetworkConfig;
+  if (!config.url) {
+    throw PluginError(`No RPC url for '${name}' network`);;
+  } else {
+    return config.url;
+  }
+}
+
+// Heuristically determine if the RPC endpoint supports debug_traceTransaction RPC.
 async function shouldDisableTracer(): Promise<boolean> {
   try {
     await hre.ethers.provider.send("debug_traceTransaction",
       [hre.ethers.constants.HashZero, {tracer: "callTracer"}]);
+    return false;
   } catch (e: any) {
-    if (e instanceof Error && e.message.includes("non-default tracer not supported yet")) {
-      return true; // anvil does not support tracers
+    if (e instanceof Error) {
+      if (e.message.includes("non-default tracer not supported yet")) {
+        return true; // anvil does not support tracers
+      } else if (e.message.includes("Method debug_traceTransaction not found")) {
+        return true; // hardhat node does not support tracers
+      } else if (e.message.includes("transaction 0000000000000000000000000000000000000000000000000000000000000000 not found")) {
+        return false; // It seems the tracers are supported.
+      }
     }
+    console.log("Cannot recognize debug_traceTransaction error:", e);
+    return true; // Otherwise disable by default.
   }
-  return false; // otherwise leave it up to Blockscout.
 }
 
 async function waitServer(url: string, maxRetry: number = 10): Promise<boolean> {


### PR DESCRIPTION
Update `explorer` task
- `--stop` stops container before doing anything
- Improve debug_traceTransaction detection
- Use correct RPC endpoint from hre.network