### PR TITLE
Extend hre.ethers.getWallets

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { extendEnvironment } from "hardhat/config";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
-import { PluginError } from "./helpers";
+import { getWallet, getWallets, PluginError } from "./helpers";
 
 import "./type-extensions";
 
@@ -12,6 +12,11 @@ extendEnvironment((hre: HardhatRuntimeEnvironment) => {
     throw PluginError("hardhat-deploy plugin not loaded. In your hardhat.config.js, please require or import 'hardhat-deploy' before hardhat-utils");
   }
   // Because hardhat-dodoc is a non-critical feature, don't check here.
+
+  // Extend hre.ethers
+  // See https://github.com/NomicFoundation/hardhat/blob/main/packages/hardhat-ethers/src/internal/index.ts
+  hre.ethers.getWallet = getWallet;
+  hre.ethers.getWallets = getWallets;
 });
 
 export * from "./abi";

--- a/src/type-extensions.ts
+++ b/src/type-extensions.ts
@@ -1,7 +1,10 @@
 import "@nomiclabs/hardhat-ethers/internal/type-extensions";
+import "@nomiclabs/hardhat-ethers/types";
 import "hardhat-deploy/dist/src/type-extensions";
-import {HardhatRuntimeEnvironment} from "hardhat/types";
 import "hardhat/types/config";
+
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import type ethers from "ethers";
 
 declare module "hardhat/types/config" {
   export interface HardhatConfig {
@@ -15,6 +18,15 @@ declare module "hardhat/types/config" {
       keepFileStructure: boolean;
       freshOutput: boolean;
     }
+  }
+}
+
+// Extend `hre.ethers` next to the fields added by hardhat-ethers.
+// See https://github.com/NomicFoundation/hardhat/blob/main/packages/hardhat-ethers/src/types/index.ts
+declare module "@nomiclabs/hardhat-ethers/types" {
+  interface HardhatEthersHelpers {
+    getWallet: (address: string) => Promise<ethers.Wallet>;
+    getWallets: () => Promise<ethers.Wallet[]>;
   }
 }
 


### PR DESCRIPTION
Add new `hre.ethers` methods

- `async getWallets(): ethers.Wallet[]`, is similar to `getSigners()` but returns Wallets containing private keys.
- `async getWallet(address): ethers.Wallet`, is similar to `getSigner(address)` but returns Wallet containing a private key.

`import "@klaytn/hardhat-utils"` to silently inject those two methods to the global `hre.ethers` object. (the same method `@nomiclabs/hardhat-ethers` use)

Example:
```ts
// hardhat.config.ts
import { task } from "hardhat/config";
import "@nomiclabs/hardhat-ethers";  // hre.ethers added
import "hardhat-deploy";
import "@klaytn/hardhat-utils";             // hre.ethers.getWallets added

task("list-accounts", async () => {
  // let accounts = await hre.ethers.getSigners();
  let accounts = await hre.ethers.getWallets();
  for (let account of accounts) {
    console.log(account.address, account.privateKey);
  }
});
```