### PR TITLE
Lazily extend hre.ethers using ES6 Proxy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@klaytn/hardhat-utils",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@klaytn/hardhat-utils",
-      "version": "0.0.7",
+      "version": "0.0.8",
       "license": "MIT",
       "dependencies": {
         "@koa/router": "^12.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@klaytn/hardhat-utils",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Hardhat utility tasks",
   "repository": "github:klaytn/hardhat-utils",
   "author": "",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { extendEnvironment } from "hardhat/config";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
-import { getWallet, getWallets, PluginError } from "./helpers";
+import { extendHardhatEthers, PluginError } from "./helpers";
 
 import "./type-extensions";
 
@@ -13,10 +13,8 @@ extendEnvironment((hre: HardhatRuntimeEnvironment) => {
   }
   // Because hardhat-dodoc is a non-critical feature, don't check here.
 
-  // Extend hre.ethers
-  // See https://github.com/NomicFoundation/hardhat/blob/main/packages/hardhat-ethers/src/internal/index.ts
-  hre.ethers.getWallet = getWallet;
-  hre.ethers.getWallets = getWallets;
+  // Lazy extend the `hre.ethers` object using the ES6 object Proxy
+  hre.ethers = new Proxy(hre.ethers, extendHardhatEthers);
 });
 
 export * from "./abi";


### PR DESCRIPTION
Fixes compatibility problem with solidity-coverage.

Used ES6 Proxy to extend `hre.ethers` object. Proxy does not trigger the [creation of the hre.ethers object](https://github.com/NomicFoundation/hardhat/blob/main/packages/hardhat-ethers/src/internal/index.ts), keeping it lazy.
Using ES6 Proxy is inspired by the hardhat's [lazyObject](https://github.com/NomicFoundation/hardhat/blob/main/packages/hardhat-core/src/internal/util/lazy.ts).