### PR TITLE
Add rpccorsdomain option to klaytn-node

### DIFF
--- a/fixtures/klaytn/docker-compose.yml
+++ b/fixtures/klaytn/docker-compose.yml
@@ -24,7 +24,7 @@ services:
           --datadir /klaytn \
           --netrestrict "127.0.0.1/32" --nodiscover --bootnodes "127.0.0.1" \
           --ipcpath /klaytn/klay.ipc \
-          --rpc --rpcvhosts "*" --rpcaddr "0.0.0.0" --rpcport 8551 \
+          --rpc --rpcvhosts "*" --rpccorsdomain "*" --rpcaddr "0.0.0.0" --rpcport 8551 \
           --rpcapi "admin,debug,eth,governance,istanbul,klay,net,personal,rpc,txpool,web3" \
           2>>/klaytn/log/kcnd.out &
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@klaytn/hardhat-utils",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Hardhat utility tasks",
   "repository": "github:klaytn/hardhat-utils",
   "author": "",


### PR DESCRIPTION
Fixes the CORS domain errors.

CORS domain errors may occur when a web page calls the RPC on http://localhost:8545.
Adding `--rpccorsdomain "*"` option to `kcn` fixes the problem.