### PR TITLE
v0.0.15: Fix fixtures path

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@klaytn/hardhat-utils",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "Hardhat utility tasks",
   "repository": "github:klaytn/hardhat-utils",
   "author": "",

--- a/src/tasks/aaBundler.ts
+++ b/src/tasks/aaBundler.ts
@@ -18,7 +18,7 @@ task(TASK_BUNDLER, "Launch local Klaytn bundler")
   .setAction(async (taskArgs) => {
     const { host, port, dockerImageId, attachRemote, entrypoints, mnemonic, derivationPath, index } = taskArgs;
 
-    const dir = path.resolve(__dirname, "../../fixtures/bundler");
+    const dir = path.resolve(__dirname, "../fixtures/bundler");
     process.chdir(dir);
 
     const rpcUrl = await networkRpcUrlFromDocker(attachRemote);

--- a/src/tasks/blockscout.ts
+++ b/src/tasks/blockscout.ts
@@ -1,10 +1,9 @@
 import { task } from "hardhat/config";
-import { HttpNetworkConfig } from "hardhat/types";
 import _ from "lodash";
 import path from "path";
 import process from "process";
 
-import { PluginError, networkRpcUrl, networkRpcUrlFromDocker, networkSupportsTracer, runDockerCompose } from "../helpers";
+import { networkRpcUrlFromDocker, networkSupportsTracer, runDockerCompose } from "../helpers";
 import "../type-extensions";
 
 export const TASK_EXPLORER = "explorer";
@@ -18,7 +17,7 @@ task(TASK_EXPLORER, "Launch blockscout explorer")
   .setAction(async (taskArgs) => {
     const { host, port, debug, attachRemote, explorerVersion } = taskArgs;
 
-    const dir = path.resolve(__dirname, "../../fixtures/blockscout");
+    const dir = path.resolve(__dirname, "../fixtures/blockscout");
     process.chdir(dir);
 
     const rpcUrl = await networkRpcUrlFromDocker(attachRemote);

--- a/src/tasks/klaytnNode.ts
+++ b/src/tasks/klaytnNode.ts
@@ -1,13 +1,11 @@
 import type ethers from "ethers";
-import { BigNumber, Wallet } from "ethers";
+import { BigNumber, } from "ethers";
 import fs from "fs";
 import { task } from "hardhat/config";
 import _ from "lodash";
 import path from "path";
 import process from "process";
 import { PluginError, defaultDerivationPath, defaultMnemonic, deriveAccounts, runDockerCompose } from "../helpers";
-
-import { normalizeHardhatNetworkAccountsConfig } from "hardhat/internal/core/providers/util";
 
 export const TASK_KLAYTN_NODE = "klaytn-node";
 
@@ -25,9 +23,9 @@ task(TASK_KLAYTN_NODE, "Launch local Klaytn node")
   .addOptionalParam("baseFee", "(since Magma) Fix the baseFee to constant; If not specified, dynamic baseFee in 25-750", "")
   .addOptionalParam("unitPrice", "(before Magma) Unit price in ston", "25")
   .setAction(async (taskArgs) => {
-    const { attach, debug, host, port, dockerImageId, balance } = taskArgs;
+    const { attach, debug, host, port, dockerImageId } = taskArgs;
 
-    const dir = path.resolve(__dirname, "../../fixtures/klaytn");
+    const dir = path.resolve(__dirname, "../fixtures/klaytn");
     process.chdir(dir);
 
     if (attach) {


### PR DESCRIPTION
Due to the output structure change in #17, there was a bug caused by incorrect `fixtures` path.
This PR fixes the `fixtures` path and upgrades to v0.0.15.

Correct path viewed from the user:
- task src: `node_modules/@klaytn/hardhat-utils/dist/tasks/klaytnNode.js`
- fixtures: `node_modules/@klaytn/hardhat-utils/dist/fixtures`